### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   secure-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/pounce-site/Pounce-Web/security/code-scanning/1](https://github.com/pounce-site/Pounce-Web/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's steps, the following permissions are needed:
- `contents: read` to allow the workflow to read repository contents.
- `packages: write` to upload build artifacts using the `actions/upload-artifact` action.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
